### PR TITLE
Improve Flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,5 @@ source =
 show_missing = True
 
 [flake8]
-max-line-length = 80
-select = E,F,W,B,B950,C,I,TYP
-ignore = E203,E501,W503
+max-line-length = 88
+extend-ignore = E203

--- a/src/django_version_checks/checks.py
+++ b/src/django_version_checks/checks.py
@@ -188,7 +188,7 @@ def check_postgresql_version(
         except KeyError:
             continue
 
-        # See: https://www.postgresql.org/docs/current/libpq-status.html#LIBPQ-PQSERVERVERSION  # noqa: B950
+        # See: https://www.postgresql.org/docs/current/libpq-status.html#LIBPQ-PQSERVERVERSION  # noqa: E501
         pg_version = connection.pg_version
         major = (pg_version // 10_000) % 100
         if major < 10:


### PR DESCRIPTION
Use only Black compat options. Removing 'select' declaration means that plugin error codes are selected by default.
