### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/django_version_checks/apps.py
+++ b/src/django_version_checks/apps.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from django.apps import AppConfig
-from django.core.checks import Tags, register
+from django.core.checks import register
+from django.core.checks import Tags
 
 from django_version_checks import checks
 

--- a/src/django_version_checks/checks.py
+++ b/src/django_version_checks/checks.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import sys
 from functools import wraps
-from typing import Any, Callable, Dict, Generator, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import Generator
 
 from django.conf import settings
-from django.core.checks import CheckMessage, Error
+from django.core.checks import CheckMessage
+from django.core.checks import Error
 from django.db import connections
 from django.db.backends.base.base import BaseDatabaseWrapper
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.specifiers import InvalidSpecifier
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from django_version_checks.typing import CheckFunc

--- a/src/django_version_checks/typing.py
+++ b/src/django_version_checks/typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Callable, List
+from typing import Callable
+from typing import List
 
 from django.core.checks import CheckMessage
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -4,7 +4,8 @@ from contextlib import contextmanager
 from unittest import mock
 
 from django.db import connection
-from django.test import SimpleTestCase, override_settings
+from django.test import override_settings
+from django.test import SimpleTestCase
 
 from django_version_checks import checks
 


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
